### PR TITLE
Petites modifs

### DIFF
--- a/src/qfactureimpl.cpp
+++ b/src/qfactureimpl.cpp
@@ -319,6 +319,7 @@ void QfactureImpl::on_action_propos_activated()
                          "--\n"
                          "Contributeur(s) :\n"
                          " * Kévin Gomez <contact@kevingomez.fr>\n"
+                         " * Mathieu Malaterre <info@mathieumalaterre.com>\n"
                          "\n").arg(VERSION);
 
     QMessageBox::about(this, "Qfacture", msg);

--- a/src/qfactureimpl.cpp
+++ b/src/qfactureimpl.cpp
@@ -169,6 +169,11 @@ QString QfactureImpl::makeFactureReference(QString number, QString date)
     return compactDate(date) + number.rightJustified(3, '0');
 }
 
+QString QfactureImpl::makeLimitDate(QDate date)
+{
+  return date.addMonths(1).toString("yyyy-MM-dd"); // format explicit de date
+}
+
 /**
  * Compacte une date pour ensuite être utilisée dans les références de
  * factures
@@ -1528,6 +1533,7 @@ void QfactureImpl::on_fPrint_clicked()
 
     invoice_tpl.replace("{% ref %}", makeFactureReference(fNum->text(), fDate->text()))
             .replace("{% invoice_date %}", query.value(6).toString())
+            .replace("{% invoice_limit_date %}", makeLimitDate(query.value(6).toDate()))
             .replace("{% invoice_comment %}", query.value(2).toString())
             .replace("{% invoice_amount %}", query.value(1).toString())
             .replace("{% invoice_type %}", query.value(5).toString())

--- a/src/qfactureimpl.cpp
+++ b/src/qfactureimpl.cpp
@@ -1480,7 +1480,8 @@ void QfactureImpl::on_fPrint_clicked()
     QPixmap logo;
 
     // configuration du printer
-    printer.setCreator("Qfacture");
+    printer.setDocName( fType->currentText() + " " + makeFactureReference(fNum->text(), fDate->text()) );
+    printer.setCreator("Qfacture v.0.1.4");
     printer.setPageSize(QPrinter::A4);
     printer.setOutputFormat(QPrinter::PdfFormat);
     printer.setOutputFileName(makeFactureReference(fNum->text(), fDate->text()) + " - " + fType->currentText() + ".pdf");

--- a/src/qfactureimpl.h
+++ b/src/qfactureimpl.h
@@ -91,6 +91,7 @@ protected:
     QString compactDate(QString date);
     QString dateToDB(QDateEdit *date);
     QString makeFactureReference(QString number, QString date);
+    QString makeLimitDate(QDate date);
     QString getInvoiceHTMLTpl();
     QString setInvoiceHTMLTpl(QString Tpl);
 };


### PR DESCRIPTION
J'ai ajouté les meta tags dans les fichiers PDF exporté c'est plus facile de conserver les noms de document directement encapsulté dans les fichiers PDF que par nom de fichiers (en tout cas pour moi).

Merci
